### PR TITLE
fix checkpoint load

### DIFF
--- a/finetune.py
+++ b/finetune.py
@@ -173,7 +173,7 @@ def train(
         if os.path.exists(checkpoint_name):
             print(f"Restarting from {checkpoint_name}")
             adapters_weights = torch.load(checkpoint_name)
-            model = set_peft_model_state_dict(model, adapters_weights)
+            set_peft_model_state_dict(model, adapters_weights)
         else:
             print(f"Checkpoint {checkpoint_name} not found")
 

--- a/finetune.py
+++ b/finetune.py
@@ -223,11 +223,6 @@ def train(
     )
     model.config.use_cache = False
 
-    old_state_dict = model.state_dict
-    model.state_dict = (
-        lambda self, *_, **__: get_peft_model_state_dict(self, old_state_dict())
-    ).__get__(model, type(model))
-
     if torch.__version__ >= "2" and sys.platform != "win32":
         model = torch.compile(model)
 


### PR DESCRIPTION
set_peft_model_state_dict(model, adapters_weights) return None
Nên assign checkpoint model sẽ bằng None
Hôm trước em có test load checkpoint bằng lora và qlora thì có bị lỗi thừa weight + thiếu weight ảnh hưởng performance, chắc tối em sẽ thử nghiệm solution trong này xem sửa được không

https://github.com/tloen/alpaca-lora/issues/334